### PR TITLE
Prevent possible segfault in TNetContext.Free()

### DIFF
--- a/mbedtls.mod/mbedtls.bmx
+++ b/mbedtls.mod/mbedtls.bmx
@@ -186,15 +186,15 @@ Type TNetContext
 	bbdoc: 
 	End Rem
 	Method Free()
-		bmx_mbedtls_net_free(contextPtr)
-	End Method
-	
-	Method Delete()
 		If contextPtr Then
-			Free()
+			bmx_mbedtls_net_free(contextPtr)
 			bmx_mbedtls_net_delete(contextPtr)
 			contextPtr = Null
 		End If
+	End Method
+	
+	Method Delete()
+		Free()
 	End Method
 	
 End Type

--- a/mbedtls.mod/mbedtls.bmx
+++ b/mbedtls.mod/mbedtls.bmx
@@ -188,13 +188,15 @@ Type TNetContext
 	Method Free()
 		If contextPtr Then
 			bmx_mbedtls_net_free(contextPtr)
-			bmx_mbedtls_net_delete(contextPtr)
-			contextPtr = Null
 		End If
 	End Method
 	
 	Method Delete()
 		Free()
+		If contextPtr Then
+			bmx_mbedtls_net_delete(contextPtr)
+			contextPtr = Null
+		End If
 	End Method
 	
 End Type


### PR DESCRIPTION
I tracked a segfault using GDB to me using TNetContext.Free() instead of unsetting the variable, I think this will be better. Correct me if I'm wrong :)