### PR TITLE
No need to keep str ptr any more

### DIFF
--- a/libcurl.mod/curlmain.bmx
+++ b/libcurl.mod/curlmain.bmx
@@ -20,7 +20,6 @@
 
 SuperStrict
 
-Import BRL.Map
 Import BRL.Stream
 Import BRL.LinkedList
 

--- a/libcurl.mod/curlmain.bmx
+++ b/libcurl.mod/curlmain.bmx
@@ -178,6 +178,7 @@ Type TCurlEasy Extends TCurlHasLists
 				Local str:Byte Ptr = parameter.toUTF8String()
 				Local res:Int bmx_curl_easy_setopt_str(easyHandlePtr, option, str)
 				MemFree(str)
+				Return res
 			Else
 				Return bmx_curl_easy_setopt_ptr(easyHandlePtr, option, Null)
 			End If


### PR DESCRIPTION
https://curl.se/libcurl/c/curl_easy_setopt.html
"Before version 7.17.0, strings were not copied. Instead the user was forced keep them available until libcurl no longer needed them."