### PR TITLE
Added a note for CURLOPT_POSTFIELDS

### DIFF
--- a/libcurl.mod/consts.bmx
+++ b/libcurl.mod/consts.bmx
@@ -192,6 +192,9 @@ header with #httpHeader as usual.
 <p>
 To make multipart/formdata posts (aka rfc1867-posts), check out the #CURLOPT_HTTPPOST option. 
 </p>
+<p>
+<span style="color:red">Note:</span> only use with #setOptBytePtr as this option requires you to manually free the memory. Use #CURLOPT_COPYPOSTFIELDS with #setOptString for simplicity.
+</p>
 End Rem
 Const CURLOPT_POSTFIELDS:Int = CURLOPTTYPE_OBJECTPOINT + 15
 


### PR DESCRIPTION
"Strings passed to libcurl as 'char *' arguments, are copied by the library; the string storage associated to the pointer argument may be discarded or reused after curl_easy_setopt returns. The only exception to this rule is really CURLOPT_POSTFIELDS, but the alternative that copies the string CURLOPT_COPYPOSTFIELDS has some usage characteristics you need to read up on. This function does not accept input strings longer than CURL_MAX_INPUT_LENGTH (8 MB)."