### PR TITLE
Fix: Specify unsigned type for 'Only' enum flag value

### DIFF
--- a/http.mod/http_util.bmx
+++ b/http.mod/http_util.bmx
@@ -522,7 +522,7 @@ Enum EHttpAuthMethod:UInt Flags
 	DigestIE = 1 Shl 4
 	Bearer = 1 Shl 6
 	AwsSigV4 = 1 Shl 7
-	Only = 1 Shl 31
+	Only = 1:UInt Shl 31
 	Any = Basic | Digest | Negotiate | NtLm | Bearer | AwsSigV4
 	AnySafe = Digest | Negotiate | NtLm | Bearer | AwsSigV4
 End Enum


### PR DESCRIPTION
Explicitly cast '1' to unsigned to prevent potential signed integer overflow when shifted left by 31 bits.